### PR TITLE
Update main page with better link

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -6,7 +6,7 @@ linkTitle = "Seed Finding"
 
 {{< blocks/cover loading="lazy" title="Seed finding made easy !" image_anchor="top" height="full" color="orange" >}}
 <div class="mx-auto">
-	<a class="btn btn-lg btn-primary mr-3 mb-4" href="{{< relref "/docs" >}}">
+	<a class="btn btn-lg btn-primary mr-3 mb-4" href="https://github.com/SeedFinding/fnseedc">
 		Learn More <i class="fas fa-arrow-alt-circle-right ml-2"></i>
 	</a>
 	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/hube12/General-Seed-Finder-Tools">


### PR DESCRIPTION
Changed the "Learn more" link to redirect to the generally used seedfinding resources repository instead of the empty one it linked to previously.